### PR TITLE
Add window.Optanon

### DIFF
--- a/build/OneTrustKit.js
+++ b/build/OneTrustKit.js
@@ -18,46 +18,46 @@ var initialization = {
         var self = this;
         this.parseConsentMapping(forwarderSettings);
         self.parseConsentGroupIds();
-        if (Optanon && Optanon.OnConsentChanged) {
-            Optanon.OnConsentChanged(function() {
+        if (window.Optanon && window.Optanon.OnConsentChanged) {
+            window.Optanon.OnConsentChanged(function() {
                 self.parseConsentGroupIds();
                 self.createConsentEvents();
             });
         }
     },
     createConsentEvents: function () {
-        var location = window.location.href,
-            consent,
-            consentState,
-            user = mParticle.Identity.getCurrentUser();
+        if (window.Optanon) {
+            var location = window.location.href,
+                consent,
+                consentState,
+                user = mParticle.Identity.getCurrentUser();
 
-        if (user) {
-            consentState = user.getConsentState();
+            if (user) {
+                consentState = user.getConsentState();
 
-            if (!consentState) {
-                consentState = mParticle.Consent.createConsentState();
-            }
+                if (!consentState) {
+                    consentState = mParticle.Consent.createConsentState();
+                }
+                for (var key in consentMapping) {
+                    var consentPurpose = consentMapping[key];
+                    var boolean;
 
-            for (var key in consentMapping) {
-                var consentPurpose = consentMapping[key];
-                var boolean;
+                    // removes all non-digits
+                    key = key.replace(/\D/g, '');
 
-                // removes all non-digits
-                key = key.replace(/\D/g, '');
+                    if (groupIds.indexOf(key) > -1) {
+                        boolean = true;
+                    } else {
+                        boolean = false;
+                    }
 
-                if (groupIds.indexOf(key) > -1) {
-                    boolean = true;
-                } else {
-                    boolean = false;
+                    consent = mParticle.Consent.createGDPRConsent(boolean, Date.now(), consentPurpose, location);
+                    consentState.addGDPRConsentState(consentPurpose, consent);
                 }
 
-                consent = mParticle.Consent.createGDPRConsent(boolean, Date.now(), consentPurpose, location);
-                consentState.addGDPRConsentState(consentPurpose, consent);
+                user.setConsentState(consentState);
             }
-
-            user.setConsentState(consentState);
         }
-
     }
 };
 

--- a/src/integration-builder/initialization.js
+++ b/src/integration-builder/initialization.js
@@ -17,46 +17,46 @@ var initialization = {
         var self = this;
         this.parseConsentMapping(forwarderSettings);
         self.parseConsentGroupIds();
-        if (Optanon && Optanon.OnConsentChanged) {
-            Optanon.OnConsentChanged(function() {
+        if (window.Optanon && window.Optanon.OnConsentChanged) {
+            window.Optanon.OnConsentChanged(function() {
                 self.parseConsentGroupIds();
                 self.createConsentEvents();
             });
         }
     },
     createConsentEvents: function () {
-        var location = window.location.href,
-            consent,
-            consentState,
-            user = mParticle.Identity.getCurrentUser();
+        if (window.Optanon) {
+            var location = window.location.href,
+                consent,
+                consentState,
+                user = mParticle.Identity.getCurrentUser();
 
-        if (user) {
-            consentState = user.getConsentState();
+            if (user) {
+                consentState = user.getConsentState();
 
-            if (!consentState) {
-                consentState = mParticle.Consent.createConsentState();
-            }
+                if (!consentState) {
+                    consentState = mParticle.Consent.createConsentState();
+                }
+                for (var key in consentMapping) {
+                    var consentPurpose = consentMapping[key];
+                    var boolean;
 
-            for (var key in consentMapping) {
-                var consentPurpose = consentMapping[key];
-                var boolean;
+                    // removes all non-digits
+                    key = key.replace(/\D/g, '');
 
-                // removes all non-digits
-                key = key.replace(/\D/g, '');
+                    if (groupIds.indexOf(key) > -1) {
+                        boolean = true;
+                    } else {
+                        boolean = false;
+                    }
 
-                if (groupIds.indexOf(key) > -1) {
-                    boolean = true;
-                } else {
-                    boolean = false;
+                    consent = mParticle.Consent.createGDPRConsent(boolean, Date.now(), consentPurpose, location);
+                    consentState.addGDPRConsentState(consentPurpose, consent);
                 }
 
-                consent = mParticle.Consent.createGDPRConsent(boolean, Date.now(), consentPurpose, location);
-                consentState.addGDPRConsentState(consentPurpose, consent);
+                user.setConsentState(consentState);
             }
-
-            user.setConsentState(consentState);
         }
-
     }
 };
 


### PR DESCRIPTION
Realized that I should have window.Optanon, otherwise it will throw and potentially go into stack overflow due to the catch.

The only other consideration is, we check for window.Optanon, if it's available, great, but if not, we won't be able to set the OnconsentChange event. We should recommend they put the onetrust all the way at the top, but something to consider since loading both them and us is async.

Works fine on the demo app though, which I'll have over by morning with instructions.