### PR TITLE
feat:  add support for vendor consent

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,14 +15,18 @@
         "before": true,
         "beforeEach": true,
         "after": true,
-        "Leanplum": true
     },
-    "extends": "eslint:recommended",
+    "extends": [
+        "plugin:prettier/recommended",
+        "eslint:recommended"
+    ],
     "rules": {
         "indent": [
             "error",
             4,
-            { "SwitchCase": 1}
+            {
+                "SwitchCase": 1
+            }
         ],
         "linebreak-style": [
             "error",
@@ -38,11 +42,9 @@
         ],
         "no-unneeded-ternary": [
             "error",
-            { "defaultAssignment": false }
-        ],
-        "comma-dangle": [
-            "error",
-            "never"
+            {
+                "defaultAssignment": false
+            }
         ],
         "curly": [
             "error",
@@ -50,13 +52,20 @@
         ],
         "comma-spacing": [
             "error",
-            { before: false, after: true }
+            {
+                "before": false,
+                "after": true
+            }
         ],
         "quote-props": [
             "error",
             "as-needed",
-            { keywords: false, unnecessary: true, numbers: false }
+            {
+                "keywords": false,
+                "unnecessary": true,
+                "numbers": false
+            }
         ],
-        "no-multi-spaces": "error",
+        "no-multi-spaces": "error"
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,18 +15,14 @@
         "before": true,
         "beforeEach": true,
         "after": true,
+        "Leanplum": true
     },
-    "extends": [
-        "plugin:prettier/recommended",
-        "eslint:recommended"
-    ],
+    "extends": "eslint:recommended",
     "rules": {
         "indent": [
             "error",
             4,
-            {
-                "SwitchCase": 1
-            }
+            { "SwitchCase": 1}
         ],
         "linebreak-style": [
             "error",
@@ -42,9 +38,11 @@
         ],
         "no-unneeded-ternary": [
             "error",
-            {
-                "defaultAssignment": false
-            }
+            { "defaultAssignment": false }
+        ],
+        "comma-dangle": [
+            "error",
+            "never"
         ],
         "curly": [
             "error",
@@ -52,20 +50,13 @@
         ],
         "comma-spacing": [
             "error",
-            {
-                "before": false,
-                "after": true
-            }
+            { before: false, after: true }
         ],
         "quote-props": [
             "error",
             "as-needed",
-            {
-                "keywords": false,
-                "unnecessary": true,
-                "numbers": false
-            }
+            { keywords: false, unnecessary: true, numbers: false }
         ],
-        "no-multi-spaces": "error"
+        "no-multi-spaces": "error",
     }
 }

--- a/src/integration-builder/initialization.js
+++ b/src/integration-builder/initialization.js
@@ -138,7 +138,7 @@ var initialization = {
 
     createVendorConsentEvents: function() {
         var self = this;
-        if (window.OneTrust) {
+        if (window.OneTrust && window.OnegetVendorConsentsRequestV2) {
             var location = window.location.href,
                 consentState,
                 user = mParticle.Identity.getCurrentUser();
@@ -158,19 +158,19 @@ var initialization = {
                     //     ...
                     //     addtlConsent:
                     //         '1~39.43.46.55.61.70.83.89.93.108.117.122.124.131',
-                    //     vendor: { 
+                    //     vendor: {
                     //         consents: '10100111011'  //
                     //     },
                     //     ...
                     // };
                     //
                     // Google Vendors are in addtlConsent - to the right of
-                    // "1~" are ids for which Google Vendor the user has consented, 
+                    // "1~" are ids for which Google Vendor the user has consented,
                     // ie. 39, 43, 46, etc, but not 1, 2, 3 which are not in this list
                     //
                     // IAB Vendors are in vendor.consents
                     // 1 = consented, 0 = rejected. The index+1 is the IAB Vendor ID
-                    // ie. If IAB ID is 5, the index is 4 in the consent string 
+                    // ie. If IAB ID is 5, the index is 4 in the consent string
                     // to the left, or 0 (rejected))
                     setGoogleVendorRequests(
                         oneTrustVendorConsent,

--- a/src/integration-builder/initialization.js
+++ b/src/integration-builder/initialization.js
@@ -9,21 +9,36 @@ var initialization = {
     name: 'OneTrust',
     moduleId: 134,
     consentMapping: [],
+    googleVendorConsentMapping: [],
+    iabVendorConsentMapping: [],
+    generalVendorConsentMapping: [],
     getConsentGroupIds: function() {
-        return window.OnetrustActiveGroups ? window.OnetrustActiveGroups.split(',') : [];
+        return window.OnetrustActiveGroups
+            ? window.OnetrustActiveGroups.split(',')
+            : [];
+    },
+    getVendorConsent: function() {
+        window.OneTrust.getVendorConsentsRequestV2(function(consent) {
+            console.log(consent);
+        });
     },
 
     parseConsentMapping: function(rawConsentMapping) {
         var _consentMapping = {};
         if (rawConsentMapping) {
-            var parsedMapping = JSON.parse(rawConsentMapping.replace(/&quot;/g, '\"'));
+            var parsedMapping = JSON.parse(
+                rawConsentMapping.replace(/&quot;/g, '"')
+            );
 
             // TODO: [67837] Revise this to use an actual 'regulation' mapping if UI ever returns this
             parsedMapping.forEach(function(mapping) {
                 var purpose = mapping.map;
                 _consentMapping[mapping.value] = {
                     purpose: purpose,
-                    regulation: purpose === CCPA_PURPOSE ? CONSENT_REGULATIONS.CCPA : CONSENT_REGULATIONS.GDPR 
+                    regulation:
+                        purpose === CCPA_PURPOSE
+                            ? CONSENT_REGULATIONS.CCPA
+                            : CONSENT_REGULATIONS.GDPR,
                 };
             });
         }
@@ -31,18 +46,48 @@ var initialization = {
         return _consentMapping;
     },
 
+    parseVendorConsentMapping: function(rawConsentMapping) {
+        var _consentMapping = {};
+        if (rawConsentMapping) {
+            var parsedMapping = JSON.parse(
+                rawConsentMapping.replace(/&quot;/g, '"')
+            );
+            parsedMapping.forEach(function(mapping) {
+                var purpose = mapping.map;
+                _consentMapping[mapping.value] = {
+                    purpose: purpose,
+                    regulation: CONSENT_REGULATIONS.GDPR,
+                };
+            });
+        }
+        return _consentMapping;
+    },
+
     initForwarder: function(forwarderSettings) {
         var self = this;
-        self.consentMapping = self.parseConsentMapping(forwarderSettings.consentGroups);
+        self.consentMapping = self.parseConsentMapping(
+            forwarderSettings.consentGroups
+        );
+
+        self.googleVendorConsentMapping = self.parseVendorConsentMapping(
+            forwarderSettings.vendorGoogleConsentGroups
+        );
+        self.iabVendorConsentMapping = self.parseVendorConsentMapping(
+            forwarderSettings.vendorIABConsentGroups
+        );
+        self.generalVendorConsentMapping = self.parseVendorConsentMapping(
+            forwarderSettings.vendorGeneralConsentGroups
+        );
 
         // Wrap exisitng OptanonWrapper in case customer is using
         // it for something custom so we can hijack
         var OptanonWrapperCopy = window.OptanonWrapper;
 
-        window.OptanonWrapper = function () {
+        window.OptanonWrapper = function() {
             if (window.Optanon && window.Optanon.OnConsentChanged) {
                 window.Optanon.OnConsentChanged(function() {
                     self.createConsentEvents();
+                    self.createVendorConsentEvents();
                 });
             }
 
@@ -50,7 +95,7 @@ var initialization = {
             OptanonWrapperCopy();
         };
     },
-    createConsentEvents: function () {
+    createConsentEvents: function() {
         if (window.Optanon) {
             var location = window.location.href,
                 consent,
@@ -74,30 +119,174 @@ var initialization = {
                         key = key.replace(/\D/g, '');
                     }
 
-                    consentBoolean = (this.getConsentGroupIds().indexOf(key) > -1);
+                    consentBoolean =
+                        this.getConsentGroupIds().indexOf(key) > -1;
 
                     // At present, only CCPA and GDPR are known regulations
                     // Using a switch in case a new regulation is added in the future
                     switch (regulation) {
                         case CONSENT_REGULATIONS.CCPA:
-                            consent = mParticle.Consent.createCCPAConsent(consentBoolean, Date.now(), consentPurpose, location);
+                            consent = mParticle.Consent.createCCPAConsent(
+                                consentBoolean,
+                                Date.now(),
+                                consentPurpose,
+                                location
+                            );
                             consentState.setCCPAConsentState(consent);
                             break;
                         case CONSENT_REGULATIONS.GDPR:
-                            consent = mParticle.Consent.createGDPRConsent(consentBoolean, Date.now(), consentPurpose, location);
-                            consentState.addGDPRConsentState(consentPurpose, consent);
+                            consent = mParticle.Consent.createGDPRConsent(
+                                consentBoolean,
+                                Date.now(),
+                                consentPurpose,
+                                location
+                            );
+                            consentState.addGDPRConsentState(
+                                consentPurpose,
+                                consent
+                            );
                             break;
                         default:
-                            console.error('Unknown Consent Regulation', regulation);
+                            console.error(
+                                'Unknown Consent Regulation',
+                                regulation
+                            );
                     }
                 }
 
                 user.setConsentState(consentState);
             }
         }
-    }
+    },
+
+    createVendorConsentEvents: function() {
+        var self = this;
+        if (window.OneTrust) {
+            var consentState,
+                user = mParticle.Identity.getCurrentUser();
+
+            if (user) {
+                consentState = user.getConsentState();
+
+                if (!consentState) {
+                    consentState = mParticle.Consent.createConsentState();
+                }
+
+                // google consent
+                // for (var googleConsent in this.googleVendorConsentMapping) {
+                OneTrust.getVendorConsentsRequestV2(function(
+                    oneTrustVendorConsent
+                ) {
+                    // copy google consent states
+                    // this will be in the shape of "1~39.43.46.55.61.70.83.89.93.108.117.122.124.131..."
+                    setGoogleVendorRequests(
+                        oneTrustVendorConsent,
+                        self.googleVendorConsentMapping,
+                        consentState
+                    );
+
+                    setIABVendorRequests(
+                        oneTrustVendorConsent,
+                        self.iabVendorConsentMapping,
+                        consentState
+                    );
+
+                    setGeneralVendorRequests(
+                        self.getConsentGroupIds(),
+                        self.generalVendorConsentMapping,
+                        consentState
+                    );
+                });
+
+                user.setConsentState(consentState);
+            }
+        }
+    },
 };
 
+function setGoogleVendorRequests(
+    oneTrustVendorConsent,
+    googleVendorConsentMapping,
+    consentState
+) {
+    var googleConsentedVendors = oneTrustVendorConsent
+        ? oneTrustVendorConsent.addtlConsent
+              .slice()
+              .split('~')[1]
+              .split('.')
+        : null;
+
+    var consentBoolean = false;
+    var location = window.location.href;
+
+    if (googleConsentedVendors && googleConsentedVendors.length) {
+        for (var key in googleVendorConsentMapping) {
+            var consentPurpose = googleVendorConsentMapping[key].purpose;
+            consentBoolean = googleConsentedVendors.indexOf(key) > -1;
+
+            consent = mParticle.Consent.createGDPRConsent(
+                consentBoolean,
+                Date.now(),
+                consentPurpose,
+                location
+            );
+            consentState.addGDPRConsentState(consentPurpose, consent);
+        }
+    }
+}
+
+function setIABVendorRequests(
+    oneTrustVendorConsent,
+    IABVendorConsentMappings,
+    consentState
+) {
+    var IABConsentedVendors = oneTrustVendorConsent
+        ? oneTrustVendorConsent.vendor.consents
+        : null;
+    var consentBoolean = false;
+    var location = window.location.href;
+
+    for (var key in IABVendorConsentMappings) {
+        var consentPurpose = IABVendorConsentMappings[key].purpose;
+        consentBoolean = IABConsentedVendors[parseInt(key) - 1] === '1';
+
+        consent = mParticle.Consent.createGDPRConsent(
+            consentBoolean,
+            Date.now(),
+            consentPurpose,
+            location
+        );
+        consentState.addGDPRConsentState(consentPurpose, consent);
+    }
+}
+
+function setGeneralVendorRequests(
+    oneTrustVendorConsent,
+    generalVendorConsentMapping,
+    consentState
+) {
+    if (window.Optanon) {
+        var location = window.location.href,
+            consent;
+
+        for (var key in generalVendorConsentMapping) {
+            var consentPurpose = generalVendorConsentMapping[key].purpose;
+            var consentBoolean = false;
+
+            consentBoolean = oneTrustVendorConsent.indexOf(key) > -1;
+
+            consent = mParticle.Consent.createGDPRConsent(
+                consentBoolean,
+                Date.now(),
+                consentPurpose,
+                location
+            );
+
+            consentState.addGDPRConsentState(consentPurpose, consent);
+        }
+    }
+}
+
 module.exports = {
-    initialization: initialization
+    initialization: initialization,
 };

--- a/src/oneTrustWrapper.js
+++ b/src/oneTrustWrapper.js
@@ -14,92 +14,109 @@
 //  limitations under the License.
 var Initialization = require('./integration-builder/initialization').initialization;
 
-    var name = Initialization.name,
-        moduleId = Initialization.moduleId;
+var name = Initialization.name,
+    moduleId = Initialization.moduleId;
 
-    var constructor = function () {
-        var self = this,
-            isInitialized = false,
-            forwarderSettings;
+var constructor = function() {
+    var self = this,
+        isInitialized = false,
+        forwarderSettings;
 
-        self.name = Initialization.name;
+    self.name = Initialization.name;
 
-        function initForwarder(settings) {
-            forwarderSettings = settings;
-            if (!isInitialized) {
-                try {
-                    Initialization.initForwarder(forwarderSettings, isInitialized);
-                    isInitialized = true;
-                } catch (e) {
-                    console.log('Failed to initialize ' + name + ' - ' + e);
-                }
+    function initForwarder(settings) {
+        forwarderSettings = settings;
+        if (!isInitialized) {
+            try {
+                Initialization.initForwarder(forwarderSettings, isInitialized);
+                isInitialized = true;
+            } catch (e) {
+                console.log('Failed to initialize ' + name + ' - ' + e);
+            }
 
+            Initialization.createConsentEvents();
+            Initialization.createVendorConsentEvents();
+        }
+    }
+
+    function onUserIdentified() {
+        if (isInitialized) {
+            try {
                 Initialization.createConsentEvents();
+                Initialization.createVendorConsentEvents();
+            } catch (e) {
+                return {
+                    error:
+                        'Error setting user identity on forwarder ' +
+                        name +
+                        '; ' +
+                        e,
+                };
             }
-        }
-
-        function onUserIdentified() {
-            if (isInitialized) {
-                try {
-                    Initialization.createConsentEvents();
-                } catch (e) {
-                    return {error: 'Error setting user identity on forwarder ' + name + '; ' + e};
-                }
-            }
-            else {
-                return 'Can\'t set new user identities on forwader  ' + name + ', not initialized';
-            }
-        }
-
-        this.init = initForwarder;
-        this.onUserIdentified = onUserIdentified;
-        this.process = function() {
-
-        };
-    };
-
-    function getId() {
-        return moduleId;
-    }
-
-    function isObject(val) {
-        return val != null && typeof val === 'object' && Array.isArray(val) === false;
-    }
-
-    function register(config) {
-        if (!config) {
-            console.log('You must pass a config object to register the kit ' + name);
-            return;
-        }
-
-        if (!isObject(config)) {
-            console.log('\'config\' must be an object. You passed in a ' + typeof config);
-            return;
-        }
-
-        if (isObject(config.kits)) {
-            config.kits[name] = {
-                constructor: constructor
-            };
         } else {
-            config.kits = {};
-            config.kits[name] = {
-                constructor: constructor
-            };
-        }
-        console.log('Successfully registered ' + name + ' to your mParticle configuration');
-    }
-
-    if (typeof window !== 'undefined') {
-        if (window && window.mParticle && window.mParticle.addForwarder) {
-            window.mParticle.addForwarder({
-                name: name,
-                constructor: constructor,
-                getId: getId
-            });
+            return (
+                "Can't set new user identities on forwader  " +
+                name +
+                ', not initialized'
+            );
         }
     }
 
-    module.exports = {
-        register: register
-    };
+    this.init = initForwarder;
+    this.onUserIdentified = onUserIdentified;
+    this.process = function() {};
+};
+
+function getId() {
+    return moduleId;
+}
+
+function isObject(val) {
+    return (
+        val != null && typeof val === 'object' && Array.isArray(val) === false
+    );
+}
+
+function register(config) {
+    if (!config) {
+        console.log(
+            'You must pass a config object to register the kit ' + name
+        );
+        return;
+    }
+
+    if (!isObject(config)) {
+        console.log(
+            "'config' must be an object. You passed in a " + typeof config
+        );
+        return;
+    }
+
+    if (isObject(config.kits)) {
+        config.kits[name] = {
+            constructor: constructor,
+        };
+    } else {
+        config.kits = {};
+        config.kits[name] = {
+            constructor: constructor,
+        };
+    }
+    console.log(
+        'Successfully registered ' + name + ' to your mParticle configuration'
+    );
+}
+
+if (typeof window !== 'undefined') {
+    if (window && window.mParticle && window.mParticle.addForwarder) {
+        window.mParticle.addForwarder({
+            name: name,
+            constructor: constructor,
+            getId: getId,
+        });
+    }
+}
+
+module.exports = {
+    register: register,
+};

--- a/src/oneTrustWrapper.js
+++ b/src/oneTrustWrapper.js
@@ -14,109 +14,101 @@
 //  limitations under the License.
 var Initialization = require('./integration-builder/initialization').initialization;
 
-var name = Initialization.name,
-    moduleId = Initialization.moduleId;
+    var name = Initialization.name,
+        moduleId = Initialization.moduleId;
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings;
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings;
 
-    self.name = Initialization.name;
+        self.name = Initialization.name;
 
-    function initForwarder(settings) {
-        forwarderSettings = settings;
-        if (!isInitialized) {
-            try {
-                Initialization.initForwarder(forwarderSettings, isInitialized);
-                isInitialized = true;
-            } catch (e) {
-                console.log('Failed to initialize ' + name + ' - ' + e);
-            }
+        function initForwarder(settings) {
+            forwarderSettings = settings;
+            if (!isInitialized) {
+                try {
+                    Initialization.initForwarder(forwarderSettings, isInitialized);
+                    isInitialized = true;
+                } catch (e) {
+                    console.log('Failed to initialize ' + name + ' - ' + e);
+                }
 
-            Initialization.createConsentEvents();
-            Initialization.createVendorConsentEvents();
-        }
-    }
-
-    function onUserIdentified() {
-        if (isInitialized) {
-            try {
                 Initialization.createConsentEvents();
                 Initialization.createVendorConsentEvents();
-            } catch (e) {
-                return {
-                    error:
-                        'Error setting user identity on forwarder ' +
-                        name +
-                        '; ' +
-                        e,
-                };
             }
-        } else {
-            return (
-                "Can't set new user identities on forwader  " +
-                name +
-                ', not initialized'
+        }
+
+        function onUserIdentified() {
+            if (isInitialized) {
+                try {
+                    Initialization.createConsentEvents();
+                    Initialization.createVendorConsentEvents();
+                } catch (e) {
+                    return {error: 'Error setting user identity on forwarder ' + name + '; ' + e};
+                }
+            } else {
+                return 'Can\'t set new user identities on forwader ' + name + ', not initialized';
+            }
+        }
+
+        this.init = initForwarder;
+        this.onUserIdentified = onUserIdentified;
+        this.process = function() {
+
+        };
+    };
+
+    function getId() {
+        return moduleId;
+    }
+
+    function isObject(val) {
+        return (
+            val != null && typeof val === 'object' && Array.isArray(val) === false
+        );
+    }
+
+    function register(config) {
+        if (!config) {
+            console.log(
+                'You must pass a config object to register the kit ' + name
             );
+            return;
+        }
+
+        if (!isObject(config)) {
+            console.log(
+                "'config' must be an object. You passed in a " + typeof config
+            );
+            return;
+        }
+
+        if (isObject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor,
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor,
+            };
+        }
+        console.log(
+            'Successfully registered ' + name + ' to your mParticle configuration'
+        );
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId,
+            });
         }
     }
 
-    this.init = initForwarder;
-    this.onUserIdentified = onUserIdentified;
-    this.process = function() {};
-};
-
-function getId() {
-    return moduleId;
-}
-
-function isObject(val) {
-    return (
-        val != null && typeof val === 'object' && Array.isArray(val) === false
-    );
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isObject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isObject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register,
+    };

--- a/src/oneTrustWrapper.js
+++ b/src/oneTrustWrapper.js
@@ -47,7 +47,8 @@ var Initialization = require('./integration-builder/initialization').initializat
                 } catch (e) {
                     return {error: 'Error setting user identity on forwarder ' + name + '; ' + e};
                 }
-            } else {
+            }
+            else {
                 return 'Can\'t set new user identities on forwader ' + name + ', not initialized';
             }
         }
@@ -64,39 +65,31 @@ var Initialization = require('./integration-builder/initialization').initializat
     }
 
     function isObject(val) {
-        return (
-            val != null && typeof val === 'object' && Array.isArray(val) === false
-        );
+        return val != null && typeof val === 'object' && Array.isArray(val) === false;
     }
 
     function register(config) {
         if (!config) {
-            console.log(
-                'You must pass a config object to register the kit ' + name
-            );
+            console.log('You must pass a config object to register the kit ' + name);
             return;
         }
 
         if (!isObject(config)) {
-            console.log(
-                "'config' must be an object. You passed in a " + typeof config
-            );
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
             return;
         }
 
         if (isObject(config.kits)) {
             config.kits[name] = {
-                constructor: constructor,
+                constructor: constructor
             };
         } else {
             config.kits = {};
             config.kits[name] = {
-                constructor: constructor,
+                constructor: constructor
             };
         }
-        console.log(
-            'Successfully registered ' + name + ' to your mParticle configuration'
-        );
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
     }
 
     if (typeof window !== 'undefined') {
@@ -104,11 +97,11 @@ var Initialization = require('./integration-builder/initialization').initializat
             window.mParticle.addForwarder({
                 name: name,
                 constructor: constructor,
-                getId: getId,
+                getId: getId
             });
         }
     }
 
     module.exports = {
-        register: register,
+        register: register
     };


### PR DESCRIPTION
## Summary
In addition to general consent purposes, OneTrust allows for specific Vendor Consent.  OneTrust supports 3 different types of vendor consent:
1. IAB (a European consortium)
2. Google
3. General Vendor Consent

Once a customer has set up the specific consent types in the OneTrust UI, they can add them to our UI.  Previously, only `Consent Mapping` existed.  We have added `IAB Vendor`, `Google`, and `General(SDK)` Vendor Consent Mapping to the UI, which provides the exact same functionality.  Each is returned via the config as the following keys respectively: `vendorIABConsentGroups`, `vendorGoogleConsentGroups`, `vendorGeneralConsentGroups`.

<img width="489" alt="image" src="https://user-images.githubusercontent.com/5377436/168088621-35e25b78-be02-4ddc-9864-81416960d5a7.png">

The 3 additional config options are parsed just like Consent Mapping, during the initForwarder.  We leverage our GDPR framework to add these consents in the same way as previous Consent Mapping, via the method `createVendorConsentEvents`, which is invoked at the same points that `createConsentEvents` is invoked:
1. OneTrustWrapper on `initForwarder`
2.OneTrustWrapper on `onUserChanged`
3. When a user updates consent in the UI, it is updated via `window.Optanon.OnConsentChanged`

Inside `createVendorConsentEvents`, we first check for `OneTrust.getVendorConsentsRequestV2` which will only exist if the customer enabled vendor consents in the OneTrust UI.    Unfortunately, the OneTrust API for determining vendor consents is not intuitive, and each type of Vendor Consent is parsed differently.

### IAB Vendor Consent API
The callback for `getVendorConsentsRequestV2` provides a `oneTrustVendorConsent` object which contains the IAB consents.  It is under `oneTrustVendorConsent.vendor.consents` in the shape of a string of 1s and 0s. ie `0101110......`.  Each IAB vendor has an ID, which matches to the `oneTrustVendorConsent.vendor.consents` but offset by 1 since there is no ID of 0 and the string is off an index 0.  Finding the index of the vendorId will tell you if they consented or not.

### Google Vendor Consent API
`oneTrustVendorConsent` also contains the Google consents.  It is under `oneTrustVendorConsent.addtlConsent` in the shape of `'1~39.43.46.55.61.70.83.89.93.108.117.122.124.131'`.  Everything to the right of `1~` is the ID of a Google Vendor who has consented (split by `.`).  If the Google Vendor ID is not in this string, it means they did not consent. By seeing if the string contains the Vendor Id, we can set its consent.

### General Vendor Consent
This lives not on the `oneTrustVendorConsent` object, but on `window.OnetrustActiveGroups`, which is contains a string like `C0001,C0002,V1,V2'.  It is a comma separated string of what the user has consented to.  The V's are the vendor consents, although they are user editable.

## Testing Plan
Add unit test.  Did manual tests in local test app.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3993