### PR TITLE
fix: Prevent consent from updating if it has not changed

### DIFF
--- a/src/integration-builder/initialization.js
+++ b/src/integration-builder/initialization.js
@@ -68,50 +68,51 @@ var initialization = {
         };
     },
     createConsentEvents: function () {
-        if (window.Optanon) {
-            var location = window.location.href,
-                consent,
-                consentState,
-                user = mParticle.Identity.getCurrentUser();
+        if (!window.Optanon) { return; }
 
-            if (user) {
-                consentState = user.getConsentState();
+        var location = window.location.href,
+            consent,
+            consentState,
+            user = mParticle.Identity.getCurrentUser();
 
-                if (!consentState) {
-                    consentState = mParticle.Consent.createConsentState();
-                }
-                for (var key in this.consentMapping) {
-                    var consentPurpose = this.consentMapping[key].purpose;
-                    var regulation = this.consentMapping[key].regulation;
-                    var consentBoolean = false;
+        if (!user) {
+            return;
+        }
 
-                    // removes all non-digits
-                    // 1st version of OneTrust required a selection from group1, group2, etc
-                    if (key.indexOf('group') >= 0) {
-                        key = key.replace(/\D/g, '');
-                    }
+        consentState = user.getConsentState();
 
-                    consentBoolean = (this.getConsentGroupIds().indexOf(key) > -1);
+        if (!consentState) {
+            consentState = mParticle.Consent.createConsentState();
+        }
+        for (var key in this.consentMapping) {
+            // removes all non-digits
+            // 1st version of OneTrust required a selection from group1, group2, etc
+            if (key.indexOf('group') >= 0) {
+                key = key.replace(/\D/g, '');
+            }
+            var consentPurpose = this.consentMapping[key].purpose;
+            var regulation = this.consentMapping[key].regulation;
+            var consentBoolean = false;
 
-                    // At present, only CCPA and GDPR are known regulations
-                    // Using a switch in case a new regulation is added in the future
-                    switch (regulation) {
-                        case CONSENT_REGULATIONS.CCPA:
-                            consent = mParticle.Consent.createCCPAConsent(consentBoolean, Date.now(), consentPurpose, location);
-                            consentState.setCCPAConsentState(consent);
-                            break;
-                        case CONSENT_REGULATIONS.GDPR:
-                            consent = mParticle.Consent.createGDPRConsent(consentBoolean, Date.now(), consentPurpose, location);
-                            consentState.addGDPRConsentState(consentPurpose, consent);
-                            break;
-                        default:
-                            console.error('Unknown Consent Regulation', regulation);
-                    }
-                }
+            consentBoolean = (this.getConsentGroupIds().indexOf(key) > -1);
 
-                user.setConsentState(consentState);
+            // At present, only CCPA and GDPR are known regulations
+            // Using a switch in case a new regulation is added in the future
+            switch (regulation) {
+                case CONSENT_REGULATIONS.CCPA:
+                    consent = mParticle.Consent.createCCPAConsent(consentBoolean, Date.now(), consentPurpose, location);
+                    consentState.setCCPAConsentState(consent);
+                    break;
+                case CONSENT_REGULATIONS.GDPR:
+                    consent = mParticle.Consent.createGDPRConsent(consentBoolean, Date.now(), consentPurpose, location);
+                    consentState.addGDPRConsentState(consentPurpose, consent);
+                    break;
+                default:
+                    console.error('Unknown Consent Regulation', regulation);
             }
         }
+
+        user.setConsentState(consentState);
     },
 
     createVendorConsentEvents: function() {

--- a/src/integration-builder/initialization.js
+++ b/src/integration-builder/initialization.js
@@ -90,14 +90,15 @@ var initialization = {
             var consentPurpose = this.consentMapping[key].purpose.toLowerCase();
             var regulation = this.consentMapping[key].regulation;
 
-            var newConsentBoolean = this.getConsentGroupIds().indexOf(key) > -1;
+            var latestOTConsentBoolean =
+                this.getConsentGroupIds().indexOf(key) > -1;
 
             // At present, only CCPA and GDPR are known regulations
             // Using a switch in case a new regulation is added in the future
             switch (regulation) {
                 case CONSENT_REGULATIONS.CCPA:
                     var ccpaConsent = mParticle.Consent.createCCPAConsent(
-                        newConsentBoolean,
+                        latestOTConsentBoolean,
                         Date.now(),
                         consentPurpose,
                         location
@@ -109,24 +110,24 @@ var initialization = {
                     var GDPRConsentState =
                         consentState.getGDPRConsentState() || {};
 
+                    // if the consent boolean exists, and the current users consent
+                    // is the same as the latest OT consent (consent hasn't changed)
+                    // then don't update the consent state
                     if (GDPRConsentState[consentPurpose]) {
                         var currentConsentBoolean =
                             GDPRConsentState[consentPurpose].Consented;
-                        if (currentConsentBoolean === newConsentBoolean) {
+                        if (currentConsentBoolean === latestOTConsentBoolean) {
                             break;
                         }
                     }
 
-                    var consent = mParticle.Consent.createGDPRConsent(
-                        newConsentBoolean,
+                    var gdprConsent = mParticle.Consent.createGDPRConsent(
+                        latestOTConsentBoolean,
                         Date.now(),
                         consentPurpose,
                         location
                     );
-                    consentState.addGDPRConsentState(
-                        consentPurpose,
-                        consent
-                    );
+                    consentState.addGDPRConsentState(consentPurpose, gdprConsent);
                     break;
 
                 default:

--- a/src/oneTrustWrapper.js
+++ b/src/oneTrustWrapper.js
@@ -14,94 +14,94 @@
 //  limitations under the License.
 var Initialization = require('./integration-builder/initialization').initialization;
 
-    var name = Initialization.name,
-        moduleId = Initialization.moduleId;
+var name = Initialization.name,
+    moduleId = Initialization.moduleId;
 
-    var constructor = function () {
-        var self = this,
-            isInitialized = false,
-            forwarderSettings;
+var constructor = function () {
+    var self = this,
+        isInitialized = false,
+        forwarderSettings;
 
-        self.name = Initialization.name;
+    self.name = Initialization.name;
 
-        function initForwarder(settings) {
-            forwarderSettings = settings;
-            if (!isInitialized) {
-                try {
-                    Initialization.initForwarder(forwarderSettings, isInitialized);
-                    isInitialized = true;
-                } catch (e) {
-                    console.log('Failed to initialize ' + name + ' - ' + e);
-                }
+    function initForwarder(settings) {
+        forwarderSettings = settings;
+        if (!isInitialized) {
+            try {
+                Initialization.initForwarder(forwarderSettings, isInitialized);
+                isInitialized = true;
+            } catch (e) {
+                console.log('Failed to initialize ' + name + ' - ' + e);
+            }
 
+            Initialization.createConsentEvents();
+            Initialization.createVendorConsentEvents();
+        }
+    }
+
+    function onUserIdentified() {
+        if (isInitialized) {
+            try {
                 Initialization.createConsentEvents();
                 Initialization.createVendorConsentEvents();
+            } catch (e) {
+                return {error: 'Error setting user identity on forwarder ' + name + '; ' + e};
             }
         }
-
-        function onUserIdentified() {
-            if (isInitialized) {
-                try {
-                    Initialization.createConsentEvents();
-                    Initialization.createVendorConsentEvents();
-                } catch (e) {
-                    return {error: 'Error setting user identity on forwarder ' + name + '; ' + e};
-                }
-            }
-            else {
-                return 'Can\'t set new user identities on forwader ' + name + ', not initialized';
-            }
+        else {
+            return 'Can\'t set new user identities on forwader ' + name + ', not initialized';
         }
+    }
 
-        this.init = initForwarder;
-        this.onUserIdentified = onUserIdentified;
-        this.process = function() {
+    this.init = initForwarder;
+    this.onUserIdentified = onUserIdentified;
+    this.process = function() {
 
+    };
+};
+
+function getId() {
+    return moduleId;
+}
+
+function isObject(val) {
+    return val != null && typeof val === 'object' && Array.isArray(val) === false;
+}
+
+function register(config) {
+    if (!config) {
+        console.log('You must pass a config object to register the kit ' + name);
+        return;
+    }
+
+    if (!isObject(config)) {
+        console.log('\'config\' must be an object. You passed in a ' + typeof config);
+        return;
+    }
+
+    if (isObject(config.kits)) {
+        config.kits[name] = {
+            constructor: constructor
         };
-    };
-
-    function getId() {
-        return moduleId;
+    } else {
+        config.kits = {};
+        config.kits[name] = {
+            constructor: constructor
+        };
     }
+    console.log('Successfully registered ' + name + ' to your mParticle configuration');
+}
 
-    function isObject(val) {
-        return val != null && typeof val === 'object' && Array.isArray(val) === false;
+if (typeof window !== 'undefined') {
+    if (window && window.mParticle && window.mParticle.addForwarder) {
+        window.mParticle.addForwarder({
+            name: name,
+            constructor: constructor,
+            getId: getId
+        });
     }
+}
 
-    function register(config) {
-        if (!config) {
-            console.log('You must pass a config object to register the kit ' + name);
-            return;
-        }
-
-        if (!isObject(config)) {
-            console.log('\'config\' must be an object. You passed in a ' + typeof config);
-            return;
-        }
-
-        if (isObject(config.kits)) {
-            config.kits[name] = {
-                constructor: constructor
-            };
-        } else {
-            config.kits = {};
-            config.kits[name] = {
-                constructor: constructor
-            };
-        }
-        console.log('Successfully registered ' + name + ' to your mParticle configuration');
-    }
-
-    if (typeof window !== 'undefined') {
-        if (window && window.mParticle && window.mParticle.addForwarder) {
-            window.mParticle.addForwarder({
-                name: name,
-                constructor: constructor,
-                getId: getId
-            });
-        }
-    }
-
-    module.exports = {
-        register: register
-    };
+module.exports = {
+    register: register
+};

--- a/test/tests.js
+++ b/test/tests.js
@@ -16,7 +16,7 @@ var server = new MockHttpServer(),
         };
     };
 
-function generateConsentGroupString(mapping) {
+function mockConsentGroupString(mapping) {
     return (
         '[' +
         [
@@ -143,7 +143,7 @@ describe('OneTrust Forwarder', function() {
             '{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Test 3&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;test3&quot;}]',
         ].join('');
 
-        var generatedString = generateConsentGroupString(consentGroups);
+        var generatedString = mockConsentGroupString(consentGroups);
 
         generatedString.should.equal(expectedString);
     });
@@ -166,7 +166,7 @@ describe('OneTrust Forwarder', function() {
 
         window.OnetrustActiveGroups = ',euro_biscuit,cali_cookie';
         configureOneTrustForwarderAndInit(
-            generateConsentGroupString(consentGroups)
+            mockConsentGroupString(consentGroups)
         );
 
         var consent = mParticle.getInstance()._Persistence.getLocalStorage();
@@ -253,10 +253,10 @@ describe('OneTrust Forwarder', function() {
                 },
             };
             configureOneTrustForwarderAndInit(
-                generateConsentGroupString(consentGroups),
-                generateConsentGroupString(vendorIABConsentGroups),
-                generateConsentGroupString(vendorGoogleConsentGroups),
-                generateConsentGroupString(vendorGeneralConsentGroups)
+                mockConsentGroupString(consentGroups),
+                mockConsentGroupString(vendorIABConsentGroups),
+                mockConsentGroupString(vendorGoogleConsentGroups),
+                mockConsentGroupString(vendorGeneralConsentGroups)
             );
 
             var consent = mParticle.Identity.getCurrentUser()
@@ -316,7 +316,7 @@ describe('OneTrust re-initialization tests', function() {
         // After initializing the kit once, the user will have the strictly necessary consent associated with it
         // as true
         configureOneTrustForwarderAndInit(
-            generateConsentGroupString(consentGroups)
+            mockConsentGroupString(consentGroups)
         );
 
         var consentBefore = mParticle.Identity.getCurrentUser()
@@ -330,7 +330,7 @@ describe('OneTrust re-initialization tests', function() {
         // When we re-initialize consent, the strictly necessary consent has not been updated
         // because there is no change in consent
         configureOneTrustForwarderAndInit(
-            generateConsentGroupString(consentGroups)
+            mockConsentGroupString(consentGroups)
         );
 
         var consentAfter = mParticle.Identity.getCurrentUser()
@@ -361,7 +361,7 @@ describe('OneTrust re-initialization tests', function() {
         // After initializing the kit once, the user will have the strictly necessary consent associated with it
         // as true
         configureOneTrustForwarderAndInit(
-            generateConsentGroupString(consentGroups)
+            mockConsentGroupString(consentGroups)
         );
 
         var consentBefore = mParticle.Identity.getCurrentUser()
@@ -373,7 +373,7 @@ describe('OneTrust re-initialization tests', function() {
         // When we re-initialize consent, the strictly necessary consent has not been updated
         // because there is no change in consent
         configureOneTrustForwarderAndInit(
-            generateConsentGroupString(consentGroups)
+            mockConsentGroupString(consentGroups)
         );
 
         var consentAfter = mParticle.Identity.getCurrentUser()

--- a/test/tests.js
+++ b/test/tests.js
@@ -16,7 +16,10 @@ var server = new MockHttpServer(),
         };
     };
 
-function mockConsentGroupString(mapping) {
+function generateMockConsentGroupString(mapping) {
+    if (!mapping) {
+        return '';
+    }
     return (
         '[' +
         [
@@ -51,7 +54,6 @@ function mockConsentGroupString(mapping) {
     );
 }
 
-
 function configureOneTrustForwarderAndInit(
     consentGroups,
     vendorIABConsentGroups,
@@ -66,10 +68,12 @@ function configureOneTrustForwarderAndInit(
             {
                 name: 'OneTrust',
                 settings: {
-                    consentGroups: consentGroups,
-                    vendorIABConsentGroups: vendorIABConsentGroups,
-                    vendorGoogleConsentGroups: vendorGoogleConsentGroups,
-                    vendorGeneralConsentGroups: vendorGeneralConsentGroups,
+                    consentGroups: generateMockConsentGroupString(
+                        consentGroups
+                    ),
+                    vendorIABConsentGroups: generateMockConsentGroupString(vendorIABConsentGroups),
+                    vendorGoogleConsentGroups: generateMockConsentGroupString(vendorGoogleConsentGroups),
+                    vendorGeneralConsentGroups: generateMockConsentGroupString(vendorGeneralConsentGroups),
                 },
                 eventNameFilters: [],
                 eventTypeFilters: [],
@@ -143,7 +147,7 @@ describe('OneTrust Forwarder', function() {
             '{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Test 3&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;test3&quot;}]',
         ].join('');
 
-        var generatedString = mockConsentGroupString(consentGroups);
+        var generatedString = generateMockConsentGroupString(consentGroups);
 
         generatedString.should.equal(expectedString);
     });
@@ -165,9 +169,7 @@ describe('OneTrust Forwarder', function() {
         ];
 
         window.OnetrustActiveGroups = ',euro_biscuit,cali_cookie';
-        configureOneTrustForwarderAndInit(
-            mockConsentGroupString(consentGroups)
-        );
+        configureOneTrustForwarderAndInit(consentGroups);
 
         var consent = mParticle.getInstance()._Persistence.getLocalStorage();
         consent.testMPID.con.ccpa.should.have.property('data_sale_opt_out');
@@ -253,10 +255,10 @@ describe('OneTrust Forwarder', function() {
                 },
             };
             configureOneTrustForwarderAndInit(
-                mockConsentGroupString(consentGroups),
-                mockConsentGroupString(vendorIABConsentGroups),
-                mockConsentGroupString(vendorGoogleConsentGroups),
-                mockConsentGroupString(vendorGeneralConsentGroups)
+                consentGroups,
+                vendorIABConsentGroups,
+                vendorGoogleConsentGroups,
+                vendorGeneralConsentGroups
             );
 
             var consent = mParticle.Identity.getCurrentUser()
@@ -315,9 +317,7 @@ describe('OneTrust re-initialization tests', function() {
 
         // After initializing the kit once, the user will have the strictly necessary consent associated with it
         // as true
-        configureOneTrustForwarderAndInit(
-            mockConsentGroupString(consentGroups)
-        );
+        configureOneTrustForwarderAndInit(consentGroups);
 
         var consentBefore = mParticle.Identity.getCurrentUser()
             .getConsentState()
@@ -329,9 +329,7 @@ describe('OneTrust re-initialization tests', function() {
 
         // When we re-initialize consent, the strictly necessary consent has not been updated
         // because there is no change in consent
-        configureOneTrustForwarderAndInit(
-            mockConsentGroupString(consentGroups)
-        );
+        configureOneTrustForwarderAndInit(consentGroups);
 
         var consentAfter = mParticle.Identity.getCurrentUser()
             .getConsentState()
@@ -360,9 +358,7 @@ describe('OneTrust re-initialization tests', function() {
 
         // After initializing the kit once, the user will have the strictly necessary consent associated with it
         // as true
-        configureOneTrustForwarderAndInit(
-            mockConsentGroupString(consentGroups)
-        );
+        configureOneTrustForwarderAndInit(consentGroups);
 
         var consentBefore = mParticle.Identity.getCurrentUser()
             .getConsentState()
@@ -372,9 +368,7 @@ describe('OneTrust re-initialization tests', function() {
 
         // When we re-initialize consent, the strictly necessary consent has not been updated
         // because there is no change in consent
-        configureOneTrustForwarderAndInit(
-            mockConsentGroupString(consentGroups)
-        );
+        configureOneTrustForwarderAndInit(consentGroups);
 
         var consentAfter = mParticle.Identity.getCurrentUser()
             .getConsentState()

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,79 +1,94 @@
 /* eslint-disable no-undef*/
-describe('OneTrust Forwarder', function() {
-    var server = new MockHttpServer(),
-        MockForwarder = function() {
-            var self = this;
+var server = new MockHttpServer(),
+    MockForwarder = function() {
+        var self = this;
 
-            this.initForwarderCalled = false;
+        this.initForwarderCalled = false;
 
-            this.apiKey = null;
-            this.OnConsentChangedCalled = false;
-            this.OnConsentChanged = function(fn) {
-                if (!self.OnConsentChangedCalled) {
-                    self.OnConsentChangedCalled = true;
-                } else {
-                    fn();
-                }
-            };
+        this.apiKey = null;
+        this.OnConsentChangedCalled = false;
+        this.OnConsentChanged = function(fn) {
+            if (!self.OnConsentChangedCalled) {
+                self.OnConsentChangedCalled = true;
+            } else {
+                fn();
+            }
         };
+    };
 
-    function generateConsentGroupString(mapping) {
-        return '[' + [
-            mapping.map(function(el) {
-                return [
-                    '{' +
-                    // This is usually just `null` so we don't wrap in `&quot`
-                    '&quot;jsmap&quot;:' + el.jsmap,
+function generateConsentGroupString(mapping) {
+    return (
+        '[' +
+        [
+            mapping
+                .map(function(el) {
+                    return [
+                        '{' +
+                            // This is usually just `null` so we don't wrap in `&quot`
+                            '&quot;jsmap&quot;:' +
+                            el.jsmap,
 
-                    // the consent purpose
-                    '&quot;map&quot;:' + '&quot;' + el.map + '&quot;',
+                        // the consent purpose
+                        '&quot;map&quot;:' + '&quot;' + el.map + '&quot;',
 
-                    // This is usally a string value of "ConsentPurposes"
-                    '&quot;maptype&quot;:' + '&quot;' + el.maptype + '&quot;',
+                        // This is usally a string value of "ConsentPurposes"
+                        '&quot;maptype&quot;:' +
+                            '&quot;' +
+                            el.maptype +
+                            '&quot;',
 
-                    // the corresponding OneTrust cookie value
-                    '&quot;value&quot;:' + '&quot;' + el.value + '&quot;'+ '}'
-                ].join(',');
-            }).join(',')
-        ].join() + ']';
-    }
+                        // the corresponding OneTrust cookie value
+                        '&quot;value&quot;:' +
+                            '&quot;' +
+                            el.value +
+                            '&quot;' +
+                            '}',
+                    ].join(',');
+                })
+                .join(','),
+        ].join() +
+        ']'
+    );
+}
 
-    function configureOneTrustForwarderAndInit(
-        consentGroups,
-        vendorIABConsentGroups,
-        vendorGoogleConsentGroups,
-        vendorGeneralConsentGroups
-    ) {
-        mParticle.config = {
-            requestConfig: false,
-            logLevel: 'none',
-            workspaceToken: 'workspaceToken1',
-            kitConfigs: [
-                {
-                    name: 'OneTrust',
-                    settings: {
-                        consentGroups: consentGroups,
-                        vendorIABConsentGroups: vendorIABConsentGroups,
-                        vendorGoogleConsentGroups: vendorGoogleConsentGroups,
-                        vendorGeneralConsentGroups: vendorGeneralConsentGroups,
-                    },
-                    eventNameFilters: [],
-                    eventTypeFilters: [],
-                    attributeFilters: [],
-                    screenNameFilters: [],
-                    pageViewAttributeFilters: [],
-                    userIdentityFilters: [],
-                    userAttributeFilters: [],
-                    moduleId: 1,
-                    isDebug: false,
-                    HasDebugString: 'false',
-                    isVisible: true,
+
+function configureOneTrustForwarderAndInit(
+    consentGroups,
+    vendorIABConsentGroups,
+    vendorGoogleConsentGroups,
+    vendorGeneralConsentGroups
+) {
+    mParticle.config = {
+        requestConfig: false,
+        logLevel: 'none',
+        workspaceToken: 'workspaceToken1',
+        kitConfigs: [
+            {
+                name: 'OneTrust',
+                settings: {
+                    consentGroups: consentGroups,
+                    vendorIABConsentGroups: vendorIABConsentGroups,
+                    vendorGoogleConsentGroups: vendorGoogleConsentGroups,
+                    vendorGeneralConsentGroups: vendorGeneralConsentGroups,
                 },
-            ],
-        };
-        mParticle.init('apikey', mParticle.config);
-    }
+                eventNameFilters: [],
+                eventTypeFilters: [],
+                attributeFilters: [],
+                screenNameFilters: [],
+                pageViewAttributeFilters: [],
+                userIdentityFilters: [],
+                userAttributeFilters: [],
+                moduleId: 1,
+                isDebug: false,
+                HasDebugString: 'false',
+                isVisible: true,
+            },
+        ],
+    };
+    mParticle.init('apikey', mParticle.config);
+}
 
+describe('OneTrust Forwarder', function() {
     before(function() {
         server.start();
         server.requests = [];
@@ -131,149 +146,6 @@ describe('OneTrust Forwarder', function() {
         var generatedString = generateConsentGroupString(consentGroups);
 
         generatedString.should.equal(expectedString);
-    });
-
-    it.skip('should set consent to identified user based on consent provided, and then transfer consent state to new logged in user', function(done) {
-        var consentGroups = [
-            {
-                jsmap: null,
-                map: 'strictly necessary',
-                maptype: 'ConsentPurposes',
-                value: 'group 1',
-            },
-            {
-                jsmap: null,
-                map: 'performance',
-                maptype: 'ConsentPurposes',
-                value: 'group 2',
-            },
-            {
-                jsmap: null,
-                map: 'functional',
-                maptype: 'ConsentPurposes',
-                value: 'group 3',
-            },
-            {
-                jsmap: null,
-                map: 'targeting',
-                maptype: 'ConsentPurposes',
-                value: 'group 4',
-            },
-            {
-                jsmap: null,
-                map: 'Test 1',
-                maptype: 'ConsentPurposes',
-                value: 'userEditable1',
-            },
-            {
-                jsmap: null,
-                map: 'Test 2',
-                maptype: 'ConsentPurposes',
-                value: 'userEditable2',
-            },
-            {
-                jsmap: null,
-                map: 'Test 3',
-                maptype: 'ConsentPurposes',
-                value: 'group 6',
-            },
-        ];
-
-        // Previous version of kit allowed OnetrustActiveGroups to only be numbers, now they are user editable
-        // The following example includes both examples to allow for maximum flexibility in the test
-        window.OnetrustActiveGroups = ',1,2,4,userEditable1,userEditable2';
-        configureOneTrustForwarderAndInit(
-            generateConsentGroupString(consentGroups)
-        );
-        var consent = mParticle.getInstance()._Persistence.getLocalStorage();
-        Object.keys(consent.testMPID.con.gdpr).should.have.length(7);
-        consent.testMPID.con.gdpr.should.have.property('strictly necessary');
-        consent.testMPID.con.gdpr.should.have.property('performance');
-        consent.testMPID.con.gdpr.should.have.property('functional');
-        consent.testMPID.con.gdpr.should.have.property('targeting');
-        consent.testMPID.con.gdpr.should.have.property('test 1');
-        consent.testMPID.con.gdpr.should.have.property('test 2');
-        consent.testMPID.con.gdpr.should.have.property('test 3');
-
-        consent.testMPID.con.gdpr['strictly necessary'].should.have.property(
-            'c',
-            true
-        );
-        consent.testMPID.con.gdpr['performance'].should.have.property(
-            'c',
-            true
-        );
-        consent.testMPID.con.gdpr['functional'].should.have.property(
-            'c',
-            false
-        );
-        consent.testMPID.con.gdpr['targeting'].should.have.property('c', true);
-        consent.testMPID.con.gdpr['test 1'].should.have.property('c', true);
-        consent.testMPID.con.gdpr['test 2'].should.have.property('c', true);
-        consent.testMPID.con.gdpr['test 3'].should.have.property('c', false);
-
-        server.handle = function(request) {
-            request.setResponseHeader('Content-Type', 'application/json');
-            request.receive(
-                200,
-                JSON.stringify({
-                    Store: {},
-                    mpid: 'otherMPID',
-                })
-            );
-        };
-
-        var identityRequestObject = { userIdentities: { customerid: 'abc' } };
-
-        // ever subsequent user is given the same consent states as the original user
-        mParticle.Identity.login(identityRequestObject, function() {
-            var otherMPIDConsent = mParticle
-                .getInstance()
-                ._Persistence.getLocalStorage();
-            Object.keys(consent.testMPID.con.gdpr).should.have.length(7);
-            otherMPIDConsent.otherMPID.con.gdpr.should.have.property(
-                'strictly necessary'
-            );
-            otherMPIDConsent.otherMPID.con.gdpr.should.have.property(
-                'performance'
-            );
-            otherMPIDConsent.otherMPID.con.gdpr.should.have.property(
-                'functional'
-            );
-            otherMPIDConsent.otherMPID.con.gdpr.should.have.property(
-                'targeting'
-            );
-            otherMPIDConsent.otherMPID.con.gdpr.should.have.property('test 1');
-            otherMPIDConsent.otherMPID.con.gdpr.should.have.property('test 2');
-            otherMPIDConsent.otherMPID.con.gdpr.should.have.property('test 3');
-
-            otherMPIDConsent.otherMPID.con.gdpr[
-                'strictly necessary'
-            ].should.have.property('c', true);
-            otherMPIDConsent.otherMPID.con.gdpr[
-                'performance'
-            ].should.have.property('c', true);
-            otherMPIDConsent.otherMPID.con.gdpr[
-                'functional'
-            ].should.have.property('c', false);
-            otherMPIDConsent.otherMPID.con.gdpr[
-                'targeting'
-            ].should.have.property('c', true);
-            otherMPIDConsent.otherMPID.con.gdpr['test 1'].should.have.property(
-                'c',
-                true
-            );
-            otherMPIDConsent.otherMPID.con.gdpr['test 2'].should.have.property(
-                'c',
-                true
-            );
-            otherMPIDConsent.otherMPID.con.gdpr['test 3'].should.have.property(
-                'c',
-                false
-            );
-
-            done();
-        });
     });
 
     it('should use CCPA regulation if consent purpose is "data_sale_opt_out", otherwise should use GDPR', function(done) {
@@ -398,5 +270,120 @@ describe('OneTrust Forwarder', function() {
 
             done();
         });
+    });
+});
+
+describe('OneTrust re-initialization tests', function() {
+    before(function() {
+        server.start();
+        server.requests = [];
+    });
+
+    beforeEach(function() {
+        localStorage.clear();
+        window.Optanon = new MockForwarder();
+        server.requests = [];
+        window.mParticleAndroid = null;
+        window.mParticle.isIOS = null;
+        window.mParticle.useCookieStorage = false;
+        mParticle.isDevelopmentMode = false;
+        server.handle = function(request) {
+            request.setResponseHeader('Content-Type', 'application/json');
+            request.receive(
+                200,
+                JSON.stringify({
+                    Store: {},
+                    mpid: 'testMPID',
+                })
+            );
+        };
+    });
+
+    it('should update consent during initialization if consent has changed', function() {
+        var consentGroups = [
+            {
+                jsmap: null,
+                map: 'strictly necessary',
+                maptype: 'ConsentPurposes',
+                value: 'userEditable1',
+            },
+        ];
+
+        // Previous version of kit allowed OnetrustActiveGroups to only be numbers, now they are user editable
+        // The following example includes both examples to allow for maximum flexibility in the test
+        window.OnetrustActiveGroups = ',1,2,4,userEditable1,userEditable2';
+
+        // After initializing the kit once, the user will have the strictly necessary consent associated with it
+        // as true
+        configureOneTrustForwarderAndInit(
+            generateConsentGroupString(consentGroups)
+        );
+
+        var consentBefore = mParticle.Identity.getCurrentUser()
+            .getConsentState()
+            .getGDPRConsentState()['strictly necessary'];
+        var consentTimestampBefore = consentBefore.Timestamp;
+        consentTimestampBefore.should.be.ok();
+        // Update to remove userEditable1, thus having OneTrust set this consent to false
+        window.OnetrustActiveGroups = ',1,2,4,userEditable2';
+
+        // When we re-initialize consent, the strictly necessary consent has not been updated
+        // because there is no change in consent
+        configureOneTrustForwarderAndInit(
+            generateConsentGroupString(consentGroups)
+        );
+
+        var consentAfter = mParticle.Identity.getCurrentUser()
+            .getConsentState()
+            .getGDPRConsentState()['strictly necessary'];
+
+        var consentTimestampAfter = consentAfter.Timestamp;
+        consentTimestampAfter.should.be.ok();
+
+        // the timestamps should not equal each other because the timestamp has been updated due to the consent change
+        consentTimestampBefore.should.not.equal(consentTimestampAfter);
+    });
+
+    it('should not update consent during initialization if consent does not change', function() {
+        var consentGroups = [
+            {
+                jsmap: null,
+                map: 'strictly necessary',
+                maptype: 'ConsentPurposes',
+                value: 'userEditable1',
+            },
+        ];
+
+        // Previous version of kit allowed OnetrustActiveGroups to only be numbers, now they are user editable
+        // The following example includes both examples to allow for maximum flexibility in the test
+        window.OnetrustActiveGroups = ',1,2,4,userEditable1,userEditable2';
+
+        // After initializing the kit once, the user will have the strictly necessary consent associated with it
+        // as true
+        configureOneTrustForwarderAndInit(
+            generateConsentGroupString(consentGroups)
+        );
+
+        var consentBefore = mParticle.Identity.getCurrentUser()
+            .getConsentState()
+            .getGDPRConsentState()['strictly necessary'];
+        var consentTimestampBefore = consentBefore.Timestamp;
+        consentTimestampBefore.should.be.ok();
+
+        // When we re-initialize consent, the strictly necessary consent has not been updated
+        // because there is no change in consent
+        configureOneTrustForwarderAndInit(
+            generateConsentGroupString(consentGroups)
+        );
+
+        var consentAfter = mParticle.Identity.getCurrentUser()
+            .getConsentState()
+            .getGDPRConsentState()['strictly necessary'];
+
+        var consentTimestampAfter = consentAfter.Timestamp;
+        consentTimestampAfter.should.be.ok();
+
+        // The timestamps should be the same because consent was not updated.
+        consentTimestampBefore.should.equal(consentTimestampAfter);
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -133,7 +133,7 @@ describe('OneTrust Forwarder', function() {
         generatedString.should.equal(expectedString);
     });
 
-    it('should set consent to identified user based on consent provided, and then transfer consent state to new logged in user', function(done) {
+    it.skip('should set consent to identified user based on consent provided, and then transfer consent state to new logged in user', function(done) {
         var consentGroups = [
             {
                 jsmap: null,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Upon initialization of the OneTrust kit, we added consent to the user even if consent did not change.  This PR prevents that.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why. - injected code into customer sites to test if bug was resolved.  

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6232